### PR TITLE
Fix fuel prices URL

### DIFF
--- a/data/projects/index.js
+++ b/data/projects/index.js
@@ -111,7 +111,7 @@ const projects = [
   },
   {
     name: "Mauritius Fuel Prices",
-    url: "https://fuel.ramgolam.com/",
+    url: "https://fuel-prices.ramgolam.com/",
     role: ["Maintainer"],
     tech: ["TailwindCSS", "VueJS", "Google Sheet API"],
     text: "Progression of fuel prices in Mauritius (2002 - Present)",


### PR DESCRIPTION
## Summary
- Correct fuel prices link from `fuel.ramgolam.com` to `fuel-prices.ramgolam.com`

## Test plan
- [ ] Verify project card links to the correct URL