### PR TITLE
Add self-hosted blog comments (Cloudflare Worker + D1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ dist/
 dist
 # Local Netlify folder
 .netlify
+# Cloudflare worker local state (comments-worker)
+.wrangler/
+.dev.vars
 playwright-report/*
 TODO.md
 GEMINI.md

--- a/comments-worker/.dev.vars.example
+++ b/comments-worker/.dev.vars.example
@@ -1,0 +1,7 @@
+# Copy to .dev.vars for local development. Never commit .dev.vars.
+ADMIN_TOKEN=dev-admin-token
+# Turnstile "always passes" test secret — pairs with the test sitekey 1x00000000000000000000AA
+TURNSTILE_SECRET=1x0000000000000000000000000000000AA
+IP_HASH_SALT=dev-salt-not-for-production
+# Optional: leave empty to skip Discord notifications locally
+DISCORD_WEBHOOK_URL=

--- a/comments-worker/.gitignore
+++ b/comments-worker/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.wrangler/
+.dev.vars
+.admin-token
+worker-configuration.d.ts

--- a/comments-worker/README.md
+++ b/comments-worker/README.md
@@ -1,0 +1,138 @@
+# comments-worker
+
+Self-hosted comment system for [sandeep.ramgolam.com](https://sandeep.ramgolam.com), decoupled from the statically generated site. A Cloudflare Worker (Hono) with a D1 database, keyed by blog post slug. Anonymous-friendly: commenters optionally give a display name — no accounts, no email, no cookies.
+
+All new comments enter a **pending queue**. Nothing is public until approved via the admin API below — by a human with curl, or by an AI agent following the [moderation policy](#moderation-policy).
+
+**Production URL:** `https://comments.ramgolam.com` (until the custom domain is attached: the `*.workers.dev` URL printed by `wrangler deploy`).
+
+## Architecture
+
+```
+Static blog page ──(client-side fetch by slug)──▶ this Worker
+                                                    ├─ D1 "blog-comments" (comments, bans)
+                                                    ├─ Rate limit: 5 POST/min/IP
+                                                    ├─ Turnstile siteverify + honeypot + fill-time check
+                                                    └─ Discord webhook on new pending comment
+Moderator / AI agent ──(Bearer ADMIN_TOKEN)──▶ /api/admin/*
+```
+
+Spam defense is layered, cheapest first: honeypot field (`website` must stay empty) → minimum fill-time of 3s → per-IP rate limit → shadow-ban check → Cloudflare Turnstile server-side verification. Honeypot hits and shadow-banned IPs receive a **fake `201 pending`** response and are never stored — indistinguishable from success, so bots and banned trolls learn nothing.
+
+IPs are never stored raw — only as `SHA-256(IP_HASH_SALT + ip)`. Bans operate on that hash.
+
+## API contract
+
+All responses are JSON. Errors are uniformly `{"error": "<machine_code>", "message": "<human text>"}`.
+
+### Public endpoints (CORS: sandeep.ramgolam.com + localhost:4242)
+
+#### `GET /api/comments/:slug`
+
+Approved comments for a post, oldest first. Unknown slugs return an empty list, not 404.
+
+```json
+200 {
+  "slug": "my-post",
+  "count": 2,
+  "comments": [
+    { "id": 12, "author_name": "Anonymous", "body": "Great post!", "created_at": "2026-07-07T10:00:00Z" },
+    { "id": 15, "author_name": "Riya", "body": "+1", "created_at": "2026-07-07T11:30:00Z" }
+  ]
+}
+```
+
+`author_name` is coalesced to `"Anonymous"` server-side. Never exposes `ip_hash`, `status`, or `user_agent`.
+
+#### `POST /api/comments`
+
+```json
+{
+  "slug": "my-post",
+  "author_name": "Riya",
+  "body": "Nice write-up",
+  "turnstile_token": "<cf-turnstile-response>",
+  "website": "",
+  "form_started_at": 1751882400000
+}
+```
+
+- `author_name` optional (≤50 chars); `body` required (2–4000 chars); `slug` must match `^[a-z0-9][a-z0-9-]{0,199}$`
+- `website` is the honeypot — humans never see the field; it must be `""`
+- `form_started_at` is epoch ms of the user's first interaction with the form
+
+Responses:
+
+| Status | Body | Meaning |
+|---|---|---|
+| 201 | `{"id": 17, "status": "pending"}` | Queued for moderation (also returned, without storing, for honeypot/banned submissions) |
+| 400 | `{"error": "validation_failed", ...}` | Bad/missing fields |
+| 400 | `{"error": "too_fast", ...}` | Submitted <3s after starting — retry succeeds |
+| 403 | `{"error": "turnstile_failed", ...}` | Bot check failed (tokens are single-use — reset the widget before retrying) |
+| 429 | `{"error": "rate_limited", ...}` | More than 5 comments/min from one IP |
+
+### Admin endpoints (`Authorization: Bearer $ADMIN_TOKEN`, no CORS — curl/agents only)
+
+```bash
+export API=https://comments.ramgolam.com
+export AUTH='Authorization: Bearer '"$ADMIN_TOKEN"
+
+# Moderation queue (status defaults to pending; also: approved, spam; limit ≤200, offset for paging)
+curl -H "$AUTH" "$API/api/admin/comments?status=pending&limit=50&offset=0"
+# → {"count": 1, "comments": [{full rows incl. ip_hash, user_agent, status, parent_id}]}
+
+curl -X POST   -H "$AUTH" "$API/api/admin/comments/17/approve"   # → {"id":17,"status":"approved"}
+curl -X POST   -H "$AUTH" "$API/api/admin/comments/17/spam"      # → {"id":17,"status":"spam"}
+curl -X DELETE -H "$AUTH" "$API/api/admin/comments/17"           # → {"id":17,"deleted":true}
+
+curl -H "$AUTH" "$API/api/admin/bans"
+curl -X POST -H "$AUTH" -H 'Content-Type: application/json' \
+  -d '{"ip_hash":"<64-hex from admin comment list>","reason":"spam wave"}' "$API/api/admin/bans"
+curl -X DELETE -H "$AUTH" "$API/api/admin/bans/<ip_hash>"
+```
+
+The admin comment list exposes `ip_hash` precisely so a moderator can chain "mark spam → ban ip_hash" without extra lookups. Unknown comment ids return `404 {"error":"not_found"}`; a missing/wrong token returns `401 {"error":"unauthorized"}`.
+
+## Moderation policy
+
+For human and AI moderators alike:
+
+- **Approve** anything on-topic — including criticism, corrections, and disagreement. Tone may be blunt; that's fine.
+- **Spam** = links to commercial/SEO content, gibberish, keyword stuffing, repeated identical bodies across posts.
+- **Delete** (rather than spam) good-faith mistakes: accidental duplicates, test comments, "please remove this".
+- **Ban** an `ip_hash` only after ≥2 spam comments from the same hash.
+- When unsure, leave the comment pending and flag it for a human.
+
+An AI agent moderating the queue should: fetch pending → judge each against this policy → approve/spam with one line of reasoning per comment → ban recurring spam hashes → report a summary.
+
+## Development
+
+```bash
+pnpm install
+cp .dev.vars.example .dev.vars    # Turnstile test secret in there always passes
+pnpm db:migrate:local
+pnpm dev                          # http://localhost:8787
+```
+
+Local D1 state persists under `.wrangler/state/`. `CF-Connecting-IP` is absent in `wrangler dev`; the code falls back to `127.0.0.1`.
+
+## Deployment
+
+```bash
+pnpm exec wrangler login
+pnpm exec wrangler d1 create blog-comments     # paste database_id into wrangler.jsonc
+pnpm db:migrate:remote
+
+# Secrets (mirror into .dev.vars for local dev)
+pnpm exec wrangler secret put ADMIN_TOKEN      # e.g. openssl rand -hex 32
+pnpm exec wrangler secret put TURNSTILE_SECRET # from the Turnstile widget (Invisible mode, hostname sandeep.ramgolam.com)
+pnpm exec wrangler secret put IP_HASH_SALT     # random; never rotate casually — rotating orphans every ban
+pnpm exec wrangler secret put DISCORD_WEBHOOK_URL
+
+pnpm run deploy   # NB: "run" is required — bare `pnpm deploy` is a reserved pnpm command
+# then uncomment "routes" in wrangler.jsonc (custom_domain comments.ramgolam.com) and deploy again
+```
+
+Schema changes: add a new file under `migrations/`, then apply with **both** `pnpm db:migrate:local` and `pnpm db:migrate:remote` — the two sides track migration state separately.
+
+The frontend embed lives in the main site: `components/blog-comments.vue`, wired to this API via `runtimeConfig.public.commentsApiUrl` in `nuxt.config.ts`.

--- a/comments-worker/migrations/0001_init.sql
+++ b/comments-worker/migrations/0001_init.sql
@@ -1,0 +1,22 @@
+-- Migration number: 0001 	 blog comments initial schema
+CREATE TABLE comments (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  slug        TEXT    NOT NULL,
+  author_name TEXT,                          -- NULL = anonymous; public API coalesces to 'Anonymous'
+  body        TEXT    NOT NULL CHECK (length(body) BETWEEN 2 AND 4000),
+  status      TEXT    NOT NULL DEFAULT 'pending' CHECK (status IN ('pending','approved','spam')),
+  parent_id   INTEGER REFERENCES comments(id), -- reserved for threading; always NULL in v1
+  ip_hash     TEXT    NOT NULL,               -- hex SHA-256(IP_HASH_SALT + ip)
+  user_agent  TEXT,
+  created_at  TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);
+
+CREATE INDEX idx_comments_slug_status ON comments (slug, status, created_at);
+CREATE INDEX idx_comments_status      ON comments (status, created_at);
+CREATE INDEX idx_comments_ip_hash     ON comments (ip_hash);
+
+CREATE TABLE bans (
+  ip_hash    TEXT PRIMARY KEY,
+  reason     TEXT,
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+);

--- a/comments-worker/package.json
+++ b/comments-worker/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "comments-worker",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@9.12.0",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "check": "tsc --noEmit",
+    "db:migrate:local": "wrangler d1 migrations apply blog-comments --local",
+    "db:migrate:remote": "wrangler d1 migrations apply blog-comments --remote",
+    "types": "wrangler types",
+    "tail": "wrangler tail"
+  },
+  "dependencies": {
+    "hono": "^4.6.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250601.0",
+    "typescript": "^5.5.0",
+    "wrangler": "^4.40.0"
+  }
+}

--- a/comments-worker/pnpm-lock.yaml
+++ b/comments-worker/pnpm-lock.yaml
@@ -1,0 +1,882 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      hono:
+        specifier: ^4.6.0
+        version: 4.12.28
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20250601.0
+        version: 4.20260702.1
+      typescript:
+        specifier: ^5.5.0
+        version: 5.9.3
+      wrangler:
+        specifier: ^4.40.0
+        version: 4.107.0(@cloudflare/workers-types@4.20260702.1)
+
+packages:
+
+  '@cloudflare/kv-asset-handler@0.5.0':
+    resolution: {integrity: sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==}
+    engines: {node: '>=22.0.0'}
+
+  '@cloudflare/unenv-preset@2.16.1':
+    resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
+    peerDependencies:
+      unenv: 2.0.0-rc.24
+      workerd: '>1.20260305.0 <2.0.0-0'
+    peerDependenciesMeta:
+      workerd:
+        optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
+    resolution: {integrity: sha512-Zd9Y1bah6DwwBN2RW8vJohffQrIUazb8UXnqSNecOxM+jJLhUuvv5IOG8dbHcV83TyZAubea6gsQXo2yH1lDdw==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
+    resolution: {integrity: sha512-yBLsjS1qCWqFyCY37qRUrYfzHHvMGvjh8zRKJ6MvUivYDhkZTzqduppK38FoqYvayLJ5KbcxH7zo5rkxGqbsaA==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@cloudflare/workerd-linux-64@1.20260701.1':
+    resolution: {integrity: sha512-vMfqSIMfoo4xmZXEuUVqLpSFS921YKjiR9q7kDXPi6Vld1PK74UHg9LZuBavT2KSyemHUCTpj9y/4JSYOEyQbQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
+    resolution: {integrity: sha512-HRfwbKU2pK44V2NhoM0+iH0JJSj7nQ9Wv13ifIiGYCmTtDL8/zKtEhX7kQ3D4Vy/Cpjhttl0FkfqXj1aqLDPPg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@cloudflare/workerd-windows-64@1.20260701.1':
+    resolution: {integrity: sha512-ngxCiIN9s/fM2o1IBMD0o1/mcXrv2NJVdyznh51UH8sQuvrTrXvV2nM0Uj/qU2wMwF6prgNBcdcd7AZeZGiBQA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260702.1':
+    resolution: {integrity: sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==}
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@emnapi/runtime@1.11.2':
+    resolution: {integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@poppinss/colors@4.1.6':
+    resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
+
+  '@poppinss/dumper@0.6.5':
+    resolution: {integrity: sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==}
+
+  '@poppinss/exception@1.2.3':
+    resolution: {integrity: sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==}
+
+  '@sindresorhus/is@7.2.0':
+    resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
+    engines: {node: '>=18'}
+
+  '@speed-highlight/core@1.2.17':
+    resolution: {integrity: sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==}
+
+  blake3-wasm@2.1.5:
+    resolution: {integrity: sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  error-stack-parser-es@1.0.5:
+    resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  hono@4.12.28:
+    resolution: {integrity: sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==}
+    engines: {node: '>=16.9.0'}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  miniflare@4.20260701.0:
+    resolution: {integrity: sha512-L6eAAi6IKtyb/7J6L+YsH2vb1yBrJWKRXI293JYDiMl70+6nncdAgigex58w6WBd+CwvdMsqOyNyGs95Op5gWQ==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  supports-color@10.2.2:
+    resolution: {integrity: sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==}
+    engines: {node: '>=18'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
+    engines: {node: '>=20.18.1'}
+
+  unenv@2.0.0-rc.24:
+    resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  workerd@1.20260701.1:
+    resolution: {integrity: sha512-uF813NG09JwNRRUfJ0zBomyTslSPM810dMj9LVvkQ7RAkLrQLzAlPU8Xh/3dIqZDo2bfd7tChbf2PtqLRARRJQ==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.107.0:
+    resolution: {integrity: sha512-fw69ThymNitZ0oIEBU2yNeq3kK59UKz/jyA3udwRrQIAIsxX57q5qLOpPTN7qc5t8n9pnUeofe0uxtMuhQZW8w==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260701.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  youch-core@0.3.3:
+    resolution: {integrity: sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==}
+
+  youch@4.1.0-beta.10:
+    resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
+
+snapshots:
+
+  '@cloudflare/kv-asset-handler@0.5.0': {}
+
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260701.1
+
+  '@cloudflare/workerd-darwin-64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-arm64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-arm64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260701.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260702.1': {}
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@emnapi/runtime@1.11.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@img/colour@1.1.0': {}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.11.2
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@poppinss/colors@4.1.6':
+    dependencies:
+      kleur: 4.1.5
+
+  '@poppinss/dumper@0.6.5':
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@sindresorhus/is': 7.2.0
+      supports-color: 10.2.2
+
+  '@poppinss/exception@1.2.3': {}
+
+  '@sindresorhus/is@7.2.0': {}
+
+  '@speed-highlight/core@1.2.17': {}
+
+  blake3-wasm@2.1.5: {}
+
+  cookie@1.1.1: {}
+
+  detect-libc@2.1.2: {}
+
+  error-stack-parser-es@1.0.5: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  fsevents@2.3.3:
+    optional: true
+
+  hono@4.12.28: {}
+
+  kleur@4.1.5: {}
+
+  miniflare@4.20260701.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.28.0
+      workerd: 1.20260701.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  path-to-regexp@6.3.0: {}
+
+  pathe@2.0.3: {}
+
+  semver@7.8.5: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+
+  supports-color@10.2.2: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typescript@5.9.3: {}
+
+  undici@7.28.0: {}
+
+  unenv@2.0.0-rc.24:
+    dependencies:
+      pathe: 2.0.3
+
+  workerd@1.20260701.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260701.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260701.1
+      '@cloudflare/workerd-linux-64': 1.20260701.1
+      '@cloudflare/workerd-linux-arm64': 1.20260701.1
+      '@cloudflare/workerd-windows-64': 1.20260701.1
+
+  wrangler@4.107.0(@cloudflare/workers-types@4.20260702.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260701.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.28.1
+      miniflare: 4.20260701.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260701.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260702.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  ws@8.21.0: {}
+
+  youch-core@0.3.3:
+    dependencies:
+      '@poppinss/exception': 1.2.3
+      error-stack-parser-es: 1.0.5
+
+  youch@4.1.0-beta.10:
+    dependencies:
+      '@poppinss/colors': 4.1.6
+      '@poppinss/dumper': 0.6.5
+      '@speed-highlight/core': 1.2.17
+      cookie: 1.1.1
+      youch-core: 0.3.3

--- a/comments-worker/src/index.ts
+++ b/comments-worker/src/index.ts
@@ -1,0 +1,36 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import type { Env } from "./types";
+import { bearerAuth } from "./middleware/auth";
+import { publicRoutes } from "./routes/public";
+import { adminRoutes } from "./routes/admin";
+
+const ALLOWED_ORIGINS = ["https://sandeep.ramgolam.com", "http://localhost:4242"];
+
+const app = new Hono<{ Bindings: Env }>();
+
+const corsMiddleware = cors({
+  origin: ALLOWED_ORIGINS,
+  allowMethods: ["GET", "POST", "OPTIONS"],
+  allowHeaders: ["Content-Type"],
+  maxAge: 86400,
+});
+// Registered before routes so preflights and 4xx error responses carry CORS
+// headers. Admin routes intentionally get no CORS — they are curl/agent only.
+app.use("/api/comments", corsMiddleware);
+app.use("/api/comments/*", corsMiddleware);
+
+app.use("/api/admin/*", bearerAuth);
+
+app.get("/", (c) => c.json({ name: "comments-worker", ok: true }));
+
+app.route("/api", publicRoutes);
+app.route("/api/admin", adminRoutes);
+
+app.notFound((c) => c.json({ error: "not_found", message: "No such endpoint" }, 404));
+app.onError((err, c) => {
+  console.error(err);
+  return c.json({ error: "internal", message: "Something went wrong" }, 500);
+});
+
+export default app;

--- a/comments-worker/src/lib/discord.ts
+++ b/comments-worker/src/lib/discord.ts
@@ -1,0 +1,37 @@
+type NotifyComment = {
+  id: number;
+  slug: string;
+  author_name: string | null;
+  body: string;
+};
+
+// Passed to ctx.waitUntil — must never reject or the runtime logs uncaught rejections.
+export async function notifyDiscord(
+  webhookUrl: string | undefined,
+  apiOrigin: string,
+  comment: NotifyComment,
+): Promise<void> {
+  if (!webhookUrl) return;
+
+  const excerpt =
+    comment.body.length > 200 ? `${comment.body.slice(0, 200)}…` : comment.body;
+  const auth = '-H "Authorization: Bearer $ADMIN_TOKEN"';
+  const content = [
+    `💬 New pending comment #${comment.id} on **${comment.slug}**`,
+    `From: ${comment.author_name ?? "Anonymous"}`,
+    `> ${excerpt.replace(/\n/g, "\n> ")}`,
+    "",
+    `Approve: \`curl -X POST ${apiOrigin}/api/admin/comments/${comment.id}/approve ${auth}\``,
+    `Spam: \`curl -X POST ${apiOrigin}/api/admin/comments/${comment.id}/spam ${auth}\``,
+  ].join("\n");
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+  } catch {
+    // Notification failures must never affect the comment submission.
+  }
+}

--- a/comments-worker/src/lib/hash.ts
+++ b/comments-worker/src/lib/hash.ts
@@ -1,0 +1,7 @@
+export async function hashIp(ip: string, salt: string): Promise<string> {
+  const data = new TextEncoder().encode(salt + ip);
+  const digest = await crypto.subtle.digest("SHA-256", data);
+  return [...new Uint8Array(digest)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/comments-worker/src/lib/turnstile.ts
+++ b/comments-worker/src/lib/turnstile.ts
@@ -1,0 +1,22 @@
+const SITEVERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify";
+
+export async function verifyTurnstile(
+  secret: string,
+  token: string,
+  remoteip?: string,
+): Promise<boolean> {
+  try {
+    const form = new FormData();
+    form.set("secret", secret);
+    form.set("response", token);
+    if (remoteip) form.set("remoteip", remoteip);
+
+    const res = await fetch(SITEVERIFY_URL, { method: "POST", body: form });
+    if (!res.ok) return false;
+
+    const data = (await res.json()) as { success?: boolean };
+    return data.success === true;
+  } catch {
+    return false;
+  }
+}

--- a/comments-worker/src/lib/validate.ts
+++ b/comments-worker/src/lib/validate.ts
@@ -1,0 +1,55 @@
+const SLUG_RE = /^[a-z0-9][a-z0-9-]{0,199}$/;
+
+export type ValidSubmission = {
+  slug: string;
+  author_name: string | null;
+  body: string;
+  turnstile_token: string;
+  website: string;
+  form_started_at: number;
+};
+
+export type ValidationResult =
+  | { ok: true; data: ValidSubmission }
+  | { ok: false; message: string };
+
+export function validateSubmission(input: unknown): ValidationResult {
+  if (typeof input !== "object" || input === null) {
+    return { ok: false, message: "Request body must be a JSON object" };
+  }
+  const raw = input as Record<string, unknown>;
+
+  const slug = typeof raw.slug === "string" ? raw.slug.trim() : "";
+  if (!SLUG_RE.test(slug)) {
+    return { ok: false, message: "Invalid slug" };
+  }
+
+  const body = typeof raw.body === "string" ? raw.body.trim() : "";
+  if (body.length < 2 || body.length > 4000) {
+    return { ok: false, message: "Comment must be between 2 and 4000 characters" };
+  }
+
+  const name = typeof raw.author_name === "string" ? raw.author_name.trim() : "";
+  if (name.length > 50) {
+    return { ok: false, message: "Name must be 50 characters or fewer" };
+  }
+
+  const turnstileToken =
+    typeof raw.turnstile_token === "string" ? raw.turnstile_token : "";
+  if (!turnstileToken) {
+    return { ok: false, message: "Missing Turnstile token" };
+  }
+
+  return {
+    ok: true,
+    data: {
+      slug,
+      author_name: name || null,
+      body,
+      turnstile_token: turnstileToken,
+      website: typeof raw.website === "string" ? raw.website : "",
+      form_started_at:
+        typeof raw.form_started_at === "number" ? raw.form_started_at : 0,
+    },
+  };
+}

--- a/comments-worker/src/middleware/auth.ts
+++ b/comments-worker/src/middleware/auth.ts
@@ -1,0 +1,21 @@
+import type { MiddlewareHandler } from "hono";
+import type { Env } from "../types";
+
+function timingSafeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const ab = encoder.encode(a);
+  const bb = encoder.encode(b);
+  if (ab.length !== bb.length) return false;
+  let diff = 0;
+  for (let i = 0; i < ab.length; i++) diff |= ab[i]! ^ bb[i]!;
+  return diff === 0;
+}
+
+export const bearerAuth: MiddlewareHandler<{ Bindings: Env }> = async (c, next) => {
+  const header = c.req.header("Authorization") ?? "";
+  const token = header.startsWith("Bearer ") ? header.slice("Bearer ".length) : "";
+  if (!token || !c.env.ADMIN_TOKEN || !timingSafeEqual(token, c.env.ADMIN_TOKEN)) {
+    return c.json({ error: "unauthorized", message: "Valid bearer token required" }, 401);
+  }
+  await next();
+};

--- a/comments-worker/src/routes/admin.ts
+++ b/comments-worker/src/routes/admin.ts
@@ -1,0 +1,98 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { CommentRow, CommentStatus, Env } from "../types";
+
+const STATUSES: CommentStatus[] = ["pending", "approved", "spam"];
+const IP_HASH_RE = /^[0-9a-f]{64}$/;
+
+export const adminRoutes = new Hono<{ Bindings: Env }>();
+
+adminRoutes.get("/comments", async (c) => {
+  const status = c.req.query("status") ?? "pending";
+  if (!STATUSES.includes(status as CommentStatus)) {
+    return c.json(
+      { error: "validation_failed", message: "status must be pending, approved or spam" },
+      400,
+    );
+  }
+  const slug = c.req.query("slug");
+  const limit = Math.min(Number(c.req.query("limit")) || 50, 200);
+  const offset = Number(c.req.query("offset")) || 0;
+
+  const query = slug
+    ? c.env.DB.prepare(
+        `SELECT * FROM comments WHERE status = ?1 AND slug = ?2
+         ORDER BY created_at ASC, id ASC LIMIT ?3 OFFSET ?4`,
+      ).bind(status, slug, limit, offset)
+    : c.env.DB.prepare(
+        `SELECT * FROM comments WHERE status = ?1
+         ORDER BY created_at ASC, id ASC LIMIT ?2 OFFSET ?3`,
+      ).bind(status, limit, offset);
+
+  const { results } = await query.all<CommentRow>();
+  return c.json({ count: results.length, comments: results });
+});
+
+async function setStatus(c: Context<{ Bindings: Env }>, status: CommentStatus) {
+  const id = c.req.param("id");
+  const row = await c.env.DB.prepare(
+    "UPDATE comments SET status = ?1 WHERE id = ?2 RETURNING id",
+  )
+    .bind(status, id)
+    .first<{ id: number }>();
+  if (!row) {
+    return c.json({ error: "not_found", message: `No comment with id ${id}` }, 404);
+  }
+  return c.json({ id: row.id, status });
+}
+
+adminRoutes.post("/comments/:id/approve", (c) => setStatus(c, "approved"));
+adminRoutes.post("/comments/:id/spam", (c) => setStatus(c, "spam"));
+
+adminRoutes.delete("/comments/:id", async (c) => {
+  const id = c.req.param("id");
+  const row = await c.env.DB.prepare("DELETE FROM comments WHERE id = ?1 RETURNING id")
+    .bind(id)
+    .first<{ id: number }>();
+  if (!row) {
+    return c.json({ error: "not_found", message: `No comment with id ${id}` }, 404);
+  }
+  return c.json({ id: row.id, deleted: true });
+});
+
+adminRoutes.get("/bans", async (c) => {
+  const { results } = await c.env.DB.prepare(
+    "SELECT ip_hash, reason, created_at FROM bans ORDER BY created_at DESC",
+  ).all();
+  return c.json({ bans: results });
+});
+
+adminRoutes.post("/bans", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "validation_failed", message: "Request body must be JSON" }, 400);
+  }
+  const ipHash = typeof body.ip_hash === "string" ? body.ip_hash.trim() : "";
+  if (!IP_HASH_RE.test(ipHash)) {
+    return c.json(
+      { error: "validation_failed", message: "ip_hash must be a 64-character hex string" },
+      400,
+    );
+  }
+  const reason = typeof body.reason === "string" ? body.reason : null;
+  await c.env.DB.prepare(
+    `INSERT INTO bans (ip_hash, reason) VALUES (?1, ?2)
+     ON CONFLICT(ip_hash) DO UPDATE SET reason = excluded.reason`,
+  )
+    .bind(ipHash, reason)
+    .run();
+  return c.json({ ip_hash: ipHash, banned: true }, 201);
+});
+
+adminRoutes.delete("/bans/:ipHash", async (c) => {
+  const ipHash = c.req.param("ipHash");
+  await c.env.DB.prepare("DELETE FROM bans WHERE ip_hash = ?1").bind(ipHash).run();
+  return c.json({ ip_hash: ipHash, banned: false });
+});

--- a/comments-worker/src/routes/public.ts
+++ b/comments-worker/src/routes/public.ts
@@ -1,0 +1,94 @@
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { Env, PublicComment } from "../types";
+import { validateSubmission } from "../lib/validate";
+import { hashIp } from "../lib/hash";
+import { verifyTurnstile } from "../lib/turnstile";
+import { notifyDiscord } from "../lib/discord";
+
+const MIN_FILL_TIME_MS = 3000;
+
+export const publicRoutes = new Hono<{ Bindings: Env }>();
+
+publicRoutes.get("/comments/:slug", async (c) => {
+  const slug = c.req.param("slug");
+  const { results } = await c.env.DB.prepare(
+    `SELECT id, COALESCE(author_name, 'Anonymous') AS author_name, body, created_at
+     FROM comments
+     WHERE slug = ?1 AND status = 'approved'
+     ORDER BY created_at ASC, id ASC`,
+  )
+    .bind(slug)
+    .all<PublicComment>();
+
+  return c.json({ slug, count: results.length, comments: results });
+});
+
+// Honeypot hits and shadow-banned IPs get a response indistinguishable from a
+// real pending comment, so bots and banned trolls learn nothing.
+function fakeAccept(c: Context<{ Bindings: Env }>) {
+  return c.json({ id: 1000 + Math.floor(Math.random() * 9000), status: "pending" }, 201);
+}
+
+publicRoutes.post("/comments", async (c) => {
+  let parsed: unknown;
+  try {
+    parsed = await c.req.json();
+  } catch {
+    return c.json({ error: "validation_failed", message: "Request body must be JSON" }, 400);
+  }
+
+  const result = validateSubmission(parsed);
+  if (!result.ok) {
+    return c.json({ error: "validation_failed", message: result.message }, 400);
+  }
+  const data = result.data;
+
+  if (data.website !== "") return fakeAccept(c);
+
+  if (!data.form_started_at || Date.now() - data.form_started_at < MIN_FILL_TIME_MS) {
+    return c.json({ error: "too_fast", message: "Please take a moment before submitting." }, 400);
+  }
+
+  const ip = c.req.header("CF-Connecting-IP") ?? "127.0.0.1";
+
+  const { success } = await c.env.POST_RATE_LIMITER.limit({ key: ip });
+  if (!success) {
+    return c.json({ error: "rate_limited", message: "Too many comments, try again in a minute." }, 429);
+  }
+
+  const ipHash = await hashIp(ip, c.env.IP_HASH_SALT);
+  const banned = await c.env.DB.prepare("SELECT 1 FROM bans WHERE ip_hash = ?1")
+    .bind(ipHash)
+    .first();
+  if (banned) return fakeAccept(c);
+
+  const human = await verifyTurnstile(c.env.TURNSTILE_SECRET, data.turnstile_token, ip);
+  if (!human) {
+    return c.json(
+      { error: "turnstile_failed", message: "Could not verify you are human, please try again." },
+      403,
+    );
+  }
+
+  const row = await c.env.DB.prepare(
+    `INSERT INTO comments (slug, author_name, body, ip_hash, user_agent)
+     VALUES (?1, ?2, ?3, ?4, ?5)
+     RETURNING id`,
+  )
+    .bind(data.slug, data.author_name, data.body, ipHash, c.req.header("User-Agent") ?? null)
+    .first<{ id: number }>();
+
+  const id = row!.id;
+  const apiOrigin = new URL(c.req.url).origin;
+  c.executionCtx.waitUntil(
+    notifyDiscord(c.env.DISCORD_WEBHOOK_URL, apiOrigin, {
+      id,
+      slug: data.slug,
+      author_name: data.author_name,
+      body: data.body,
+    }),
+  );
+
+  return c.json({ id, status: "pending" }, 201);
+});

--- a/comments-worker/src/types.ts
+++ b/comments-worker/src/types.ts
@@ -1,0 +1,36 @@
+export type RateLimiter = {
+  limit: (options: { key: string }) => Promise<{ success: boolean }>;
+};
+
+export type Env = {
+  DB: D1Database;
+  POST_RATE_LIMITER: RateLimiter;
+  ADMIN_TOKEN: string;
+  TURNSTILE_SECRET: string;
+  IP_HASH_SALT: string;
+  DISCORD_WEBHOOK_URL?: string;
+};
+
+export type CommentStatus = "pending" | "approved" | "spam";
+
+export type CommentRow = {
+  id: number;
+  slug: string;
+  author_name: string | null;
+  body: string;
+  status: CommentStatus;
+  parent_id: number | null;
+  ip_hash: string;
+  user_agent: string | null;
+  created_at: string;
+};
+
+// Mirrors PublicComment / CommentSubmission in the site's types/index.ts.
+// Kept duplicated on purpose: this package has an isolated tsconfig and the
+// README API contract is the source of truth.
+export type PublicComment = {
+  id: number;
+  author_name: string;
+  body: string;
+  created_at: string;
+};

--- a/comments-worker/tsconfig.json
+++ b/comments-worker/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}

--- a/comments-worker/wrangler.jsonc
+++ b/comments-worker/wrangler.jsonc
@@ -1,0 +1,26 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "comments-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2026-07-01",
+  "workers_dev": true,
+  "routes": [{ "pattern": "comments.ramgolam.com", "custom_domain": true }],
+  "observability": {
+    "enabled": true
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "blog-comments",
+      "database_id": "67b128ee-1e47-4565-b24e-9bab34a93e14",
+      "migrations_dir": "migrations"
+    }
+  ],
+  "ratelimits": [
+    {
+      "name": "POST_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": { "limit": 5, "period": 60 }
+    }
+  ]
+}

--- a/components/blog-comments.vue
+++ b/components/blog-comments.vue
@@ -1,0 +1,217 @@
+<script setup lang="ts">
+import type { CommentSubmission, PublicComment, PublicCommentsResponse } from "@/types";
+
+const props = defineProps<{ slug: string }>();
+
+const config = useRuntimeConfig();
+const apiBase = config.public.commentsApiUrl;
+
+const comments = ref<PublicComment[]>([]);
+const loading = ref(true);
+const loadFailed = ref(false);
+
+async function loadComments() {
+  loading.value = true;
+  loadFailed.value = false;
+  try {
+    const res = await $fetch<PublicCommentsResponse>(
+      `${apiBase}/api/comments/${props.slug}`,
+    );
+    comments.value = res.comments;
+  } catch {
+    loadFailed.value = true;
+  } finally {
+    loading.value = false;
+  }
+}
+
+onMounted(loadComments);
+
+const authorName = ref("");
+const body = ref("");
+const website = ref(""); // honeypot — humans never see the field
+const formStartedAt = ref(0);
+const submitting = ref(false);
+const submitted = ref(false);
+const submitError = ref("");
+
+const turnstileEl = ref<HTMLElement | null>(null);
+const { preload, getToken, reset } = useTurnstile(turnstileEl);
+
+function onFormInteraction() {
+  if (!formStartedAt.value) formStartedAt.value = Date.now();
+  preload();
+}
+
+function friendlyError(error: unknown): string {
+  const data = (error as { data?: { error?: string; message?: string } })?.data;
+  switch (data?.error) {
+    case "rate_limited":
+      return "You're commenting a bit fast — try again in a minute.";
+    case "too_fast":
+      return "That was quick! Give it a second and try again.";
+    case "turnstile_failed":
+      return "We couldn't verify you're human. Please try again.";
+    case "validation_failed":
+      return data?.message ?? "Please check your comment and try again.";
+    default:
+      return "Something went wrong — please try again.";
+  }
+}
+
+async function submit() {
+  if (submitting.value) return;
+  submitting.value = true;
+  submitError.value = "";
+  try {
+    const token = await getToken();
+    const submission: CommentSubmission = {
+      slug: props.slug,
+      author_name: authorName.value.trim() || undefined,
+      body: body.value,
+      turnstile_token: token,
+      website: website.value,
+      form_started_at: formStartedAt.value,
+    };
+    await $fetch(`${apiBase}/api/comments`, { method: "POST", body: submission });
+    submitted.value = true;
+  } catch (error) {
+    reset();
+    submitError.value = friendlyError(error);
+  } finally {
+    submitting.value = false;
+  }
+}
+</script>
+
+<template>
+  <section class="mt-16 mb-24">
+    <h2 class="text-2xl font-bold mb-6">Comments</h2>
+
+    <ClientOnly>
+      <div v-if="loading" class="comments-skeleton" aria-hidden="true">
+        Loading comments…
+      </div>
+
+      <div v-else-if="loadFailed" class="text-gray-500 dark:text-gray-400">
+        <p>
+          Couldn't load comments.
+          <button class="underline font-medium" type="button" @click="loadComments">
+            Retry
+          </button>
+        </p>
+      </div>
+
+      <template v-else>
+        <p v-if="comments.length === 0" class="text-gray-500 dark:text-gray-400">
+          No comments yet — be the first!
+        </p>
+        <ul v-else class="flex flex-col gap-4 list-none p-0">
+          <li
+            v-for="comment in comments"
+            :key="comment.id"
+            class="rounded-xl border border-gray-200 dark:border-gray-800 p-4"
+          >
+            <div class="flex items-baseline gap-2 mb-1">
+              <span class="font-bold">{{ comment.author_name }}</span>
+              <time
+                class="text-sm text-gray-500 dark:text-gray-400"
+                :datetime="comment.created_at"
+              >
+                {{ dateFormat(new Date(comment.created_at)) }}
+              </time>
+            </div>
+            <p class="whitespace-pre-line dark:text-gray-300 m-0">{{ comment.body }}</p>
+          </li>
+        </ul>
+      </template>
+
+      <div class="mt-8">
+        <p
+          v-if="submitted"
+          class="rounded-xl border border-green-300 dark:border-green-800 bg-green-50 dark:bg-green-950/40 p-4 text-green-800 dark:text-green-300"
+        >
+          Thanks! Your comment is awaiting moderation.
+        </p>
+
+        <form
+          v-else
+          class="flex flex-col gap-3"
+          @focusin="onFormInteraction"
+          @submit.prevent="submit"
+        >
+          <input
+            v-model="authorName"
+            type="text"
+            maxlength="50"
+            placeholder="Name (optional)"
+            class="rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2"
+          />
+          <textarea
+            v-model="body"
+            required
+            maxlength="4000"
+            rows="4"
+            placeholder="Leave a comment…"
+            class="rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2"
+          />
+          <input
+            v-model="website"
+            class="comments-hp"
+            type="text"
+            name="website"
+            tabindex="-1"
+            autocomplete="off"
+            aria-hidden="true"
+          />
+          <div ref="turnstileEl" />
+
+          <p v-if="submitError" class="text-sm text-red-600 dark:text-red-400 m-0">
+            {{ submitError }}
+          </p>
+
+          <button
+            type="submit"
+            :disabled="submitting || body.trim().length < 2"
+            class="self-start rounded-full border-2 border-gray-900 dark:border-gray-100 px-5 py-2 font-bold transition-colors hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-current"
+          >
+            {{ submitting ? "Posting…" : "Post comment" }}
+          </button>
+        </form>
+      </div>
+
+      <template #fallback>
+        <div class="comments-skeleton" aria-hidden="true">Loading comments…</div>
+      </template>
+    </ClientOnly>
+  </section>
+</template>
+
+<style scoped>
+.comments-skeleton {
+  border: 1px solid transparent;
+  border-radius: 0.75rem;
+  padding: 1rem;
+  color: rgb(107 114 128);
+  animation: comments-pulse 2s infinite;
+}
+
+@keyframes comments-pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+/* Honeypot: off-screen but not display:none, which naive bots skip */
+.comments-hp {
+  position: absolute;
+  left: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0;
+}
+</style>

--- a/composables/useTurnstile.ts
+++ b/composables/useTurnstile.ts
@@ -1,0 +1,116 @@
+import type { Ref } from "vue";
+
+type TurnstileApi = {
+  render: (el: HTMLElement, options: Record<string, unknown>) => string;
+  execute: (widgetId: string) => void;
+  reset: (widgetId: string) => void;
+  remove: (widgetId: string) => void;
+};
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi;
+  }
+}
+
+const SCRIPT_SRC =
+  "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+
+let scriptPromise: Promise<TurnstileApi> | null = null;
+
+function loadScript(): Promise<TurnstileApi> {
+  if (scriptPromise) return scriptPromise;
+  scriptPromise = new Promise((resolve, reject) => {
+    if (window.turnstile) return resolve(window.turnstile);
+    const script = document.createElement("script");
+    script.src = SCRIPT_SRC;
+    script.async = true;
+    script.onload = () => {
+      if (window.turnstile) resolve(window.turnstile);
+      else reject(new Error("turnstile_load_failed"));
+    };
+    script.onerror = () => {
+      scriptPromise = null;
+      reject(new Error("turnstile_load_failed"));
+    };
+    document.head.appendChild(script);
+  });
+  return scriptPromise;
+}
+
+/**
+ * Lazy Cloudflare Turnstile: the script is only injected once the visitor
+ * interacts with the comment form (via preload()), so blog pages stay light.
+ * The widget renders in interaction-only mode and runs on getToken().
+ */
+export function useTurnstile(container: Ref<HTMLElement | null>) {
+  const config = useRuntimeConfig();
+  const siteKey = config.public.turnstileSiteKey;
+
+  let widgetId: string | null = null;
+  let pending: { resolve: (token: string) => void; reject: (error: Error) => void } | null =
+    null;
+
+  async function ensureWidget(): Promise<TurnstileApi> {
+    const turnstile = await loadScript();
+    if (widgetId === null && container.value) {
+      widgetId = turnstile.render(container.value, {
+        sitekey: siteKey,
+        execution: "execute",
+        appearance: "interaction-only",
+        theme: "auto",
+        callback: (token: string) => {
+          pending?.resolve(token);
+          pending = null;
+        },
+        "error-callback": () => {
+          pending?.reject(new Error("turnstile_error"));
+          pending = null;
+        },
+        "expired-callback": () => {
+          if (widgetId !== null) window.turnstile?.reset(widgetId);
+        },
+      });
+    }
+    return turnstile;
+  }
+
+  function preload() {
+    ensureWidget().catch(() => {});
+  }
+
+  async function getToken(timeoutMs = 30_000): Promise<string> {
+    const turnstile = await ensureWidget();
+    if (widgetId === null) throw new Error("turnstile_error");
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        pending = null;
+        reject(new Error("turnstile_timeout"));
+      }, timeoutMs);
+      pending = {
+        resolve: (token) => {
+          clearTimeout(timer);
+          resolve(token);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      };
+      turnstile.execute(widgetId!);
+    });
+  }
+
+  // Tokens are single-use — call after any failed submission before retrying.
+  function reset() {
+    if (widgetId !== null) window.turnstile?.reset(widgetId);
+  }
+
+  onUnmounted(() => {
+    if (widgetId !== null) window.turnstile?.remove(widgetId);
+    widgetId = null;
+    pending = null;
+  });
+
+  return { preload, getToken, reset };
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -57,6 +57,16 @@ export default defineNuxtConfig({
     }
   },
 
+  // Baked into the static build at `pnpm generate` time — defaults must be the
+  // production values. Local overrides via NUXT_PUBLIC_* env vars in .env.
+  runtimeConfig: {
+    public: {
+      commentsApiUrl: "https://comments.ramgolam.com",
+      // Turnstile sitekeys are public — safe to commit (see comments-worker/README.md)
+      turnstileSiteKey: "0x4AAAAAADxcem8PeL7oRLW6",
+    },
+  },
+
   compatibilityDate: "2025-12-09",
 
   // Configure image optimization

--- a/pages/blog/[...slug].vue
+++ b/pages/blog/[...slug].vue
@@ -96,6 +96,8 @@ const coverImage = computed(() => {
           <ContentRenderer :value="post" />
         </div>
       </article>
+
+      <BlogComments :slug="slug" />
     </div>
   </article>
 </template>

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,3 +1,26 @@
+// Mirrors the comments-worker API contract (comments-worker/README.md)
+export type PublicComment = {
+  id: number;
+  author_name: string; // already coalesced to 'Anonymous' by the API
+  body: string;
+  created_at: string; // ISO-8601
+};
+
+export type PublicCommentsResponse = {
+  slug: string;
+  count: number;
+  comments: PublicComment[];
+};
+
+export type CommentSubmission = {
+  slug: string;
+  author_name?: string;
+  body: string;
+  turnstile_token: string;
+  website: string; // honeypot — always ''
+  form_started_at: number; // epoch ms of first form interaction
+};
+
 export type BlogPost = {
   title: string;
   slug: string;


### PR DESCRIPTION
## Summary

- **`comments-worker/`** — a self-contained Cloudflare Worker (Hono + D1) serving `https://comments.ramgolam.com`, fully decoupled from the static site. Comments are keyed by post slug, anonymous-friendly (optional name, no accounts), and land in a **pending moderation queue** by default.
- **Moderation** via a bearer-token REST API (list/approve/spam/delete/ban) designed to be driven by curl or an AI agent — full contract + moderation policy in `comments-worker/README.md`.
- **Spam defense in layers**: honeypot, 3s minimum fill-time, 5 posts/min/IP rate limit, shadow-bans (banned IPs get a fake success), and Cloudflare Turnstile (invisible) verification.
- **Discord webhook** notification for each new pending comment, with copy-paste approve/spam curl commands.
- **Frontend**: `<BlogComments>` island below each blog post — client-only so the site stays fully static; the Turnstile script loads lazily only when a reader interacts with the form.

## Deployment state

Worker is already live (D1 migrated, secrets set, custom domain attached). Merging this deploys the site half.

## Test plan

- [x] Full API lifecycle via curl, local + production (post → pending → approve → visible; spam/delete; shadow-ban; 429 on burst; CORS preflight; 401 on bad token)
- [x] Browser end-to-end on local dev: submit → "awaiting moderation" → approve → renders; light + dark mode; no console errors; Turnstile script absent until form focus
- [x] `pnpm generate` bakes production API URL + sitekey (verified in output HTML)
- [ ] Post-deploy: submit a real comment on production (real Turnstile challenge + Discord ping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)