### PR TITLE
Comment threading, admin dashboard, own-pending visibility

### DIFF
--- a/comments-worker/README.md
+++ b/comments-worker/README.md
@@ -36,13 +36,13 @@ Approved comments for a post, oldest first. Unknown slugs return an empty list, 
   "slug": "my-post",
   "count": 2,
   "comments": [
-    { "id": 12, "author_name": "Anonymous", "body": "Great post!", "created_at": "2026-07-07T10:00:00Z" },
-    { "id": 15, "author_name": "Riya", "body": "+1", "created_at": "2026-07-07T11:30:00Z" }
+    { "id": 12, "author_name": "Anonymous", "body": "Great post!", "parent_id": null, "created_at": "2026-07-07T10:00:00Z" },
+    { "id": 15, "author_name": "Riya", "body": "+1", "parent_id": 12, "created_at": "2026-07-07T11:30:00Z" }
   ]
 }
 ```
 
-`author_name` is coalesced to `"Anonymous"` server-side. Never exposes `ip_hash`, `status`, or `user_agent`.
+`author_name` is coalesced to `"Anonymous"` server-side. Never exposes `ip_hash`, `status`, or `user_agent`. `parent_id` supports one level of threading — replies reference a top-level comment.
 
 #### `POST /api/comments`
 
@@ -60,6 +60,7 @@ Approved comments for a post, oldest first. Unknown slugs return an empty list, 
 - `author_name` optional (≤50 chars); `body` required (2–4000 chars); `slug` must match `^[a-z0-9][a-z0-9-]{0,199}$`
 - `website` is the honeypot — humans never see the field; it must be `""`
 - `form_started_at` is epoch ms of the user's first interaction with the form
+- `parent_id` optional — makes the comment a reply; must reference an **approved, top-level** comment on the same slug (one level of threading only), otherwise `400 validation_failed`
 
 Responses:
 
@@ -83,7 +84,7 @@ curl -H "$AUTH" "$API/api/admin/comments?status=pending&limit=50&offset=0"
 
 curl -X POST   -H "$AUTH" "$API/api/admin/comments/17/approve"   # → {"id":17,"status":"approved"}
 curl -X POST   -H "$AUTH" "$API/api/admin/comments/17/spam"      # → {"id":17,"status":"spam"}
-curl -X DELETE -H "$AUTH" "$API/api/admin/comments/17"           # → {"id":17,"deleted":true}
+curl -X DELETE -H "$AUTH" "$API/api/admin/comments/17"           # → {"id":17,"deleted":true} (replies go with it)
 
 curl -H "$AUTH" "$API/api/admin/bans"
 curl -X POST -H "$AUTH" -H 'Content-Type: application/json' \
@@ -92,6 +93,19 @@ curl -X DELETE -H "$AUTH" "$API/api/admin/bans/<ip_hash>"
 ```
 
 The admin comment list exposes `ip_hash` precisely so a moderator can chain "mark spam → ban ip_hash" without extra lookups. Unknown comment ids return `404 {"error":"not_found"}`; a missing/wrong token returns `401 {"error":"unauthorized"}`.
+
+## Moderating from the browser
+
+- **Admin dashboard**: `https://comments.ramgolam.com/admin` — paste the admin token once (kept in that browser's localStorage under `comments_admin_token`). Tabs for pending/approved/spam/bans with approve/spam/delete/ban buttons. The page itself contains no data; every request goes through the bearer-auth API.
+- **Pending comments inline on the blog**: the `<BlogComments>` component also shows the pending queue for that post — with a "pending" badge — when the same token is present in localStorage **on the blog's origin** (localStorage does not cross origins). Set it once in the devtools console on sandeep.ramgolam.com:
+
+  ```js
+  localStorage.setItem("comments_admin_token", "<token>")
+  ```
+
+  Without a token, the blog makes no admin request at all. A stale/wrong token fails silently (public comments still render).
+
+Commenters also keep seeing **their own** pending comments on the blog: after a successful submission the component remembers the comment in localStorage (`comments_mine`, per slug, 60-day cap) and shows it with the "pending" badge until it appears in the approved list. This is purely client-side — other visitors see nothing, and shadow-banned submitters conveniently keep believing their comment is queued.
 
 ## Moderation policy
 

--- a/comments-worker/src/admin-page.ts
+++ b/comments-worker/src/admin-page.ts
@@ -1,0 +1,201 @@
+// Single-file admin dashboard served at /admin. Contains no data itself —
+// everything is fetched same-origin from /api/admin/* with the bearer token
+// the moderator pastes once (kept in localStorage).
+export const ADMIN_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Blog Comments Admin</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f8fafc; --card: #ffffff; --text: #0f172a; --muted: #64748b;
+    --border: #e2e8f0; --accent: #16a34a; --danger: #dc2626; --warn: #d97706;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #0f172a; --card: #1e293b; --text: #e2e8f0; --muted: #94a3b8; --border: #334155; }
+  }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: var(--bg); color: var(--text);
+    font: 15px/1.5 system-ui, -apple-system, sans-serif; }
+  .wrap { max-width: 760px; margin: 0 auto; padding: 1.5rem 1rem 4rem; }
+  header { display: flex; align-items: baseline; justify-content: space-between; gap: 1rem; }
+  h1 { font-size: 1.3rem; margin: 0 0 1rem; }
+  nav { display: flex; gap: .5rem; margin: 1rem 0; flex-wrap: wrap; }
+  nav button { border: 1px solid var(--border); background: var(--card); color: var(--text);
+    border-radius: 999px; padding: .4rem 1rem; cursor: pointer; font: inherit; }
+  nav button.active { border-color: var(--accent); color: var(--accent); font-weight: 700; }
+  .card { background: var(--card); border: 1px solid var(--border); border-radius: .75rem;
+    padding: 1rem; margin-bottom: .75rem; }
+  .meta { display: flex; gap: .6rem; flex-wrap: wrap; align-items: baseline;
+    font-size: .85rem; color: var(--muted); margin-bottom: .4rem; }
+  .meta b { color: var(--text); font-size: 1rem; }
+  .meta a { color: var(--muted); }
+  .body { white-space: pre-line; overflow-wrap: anywhere; margin: 0 0 .75rem; }
+  .actions { display: flex; gap: .5rem; flex-wrap: wrap; }
+  .actions button { border: 1px solid var(--border); background: transparent; color: var(--text);
+    border-radius: .5rem; padding: .3rem .8rem; cursor: pointer; font: inherit; font-size: .85rem; }
+  .actions button:hover { border-color: currentColor; }
+  .approve { color: var(--accent); } .spam { color: var(--warn); }
+  .del, .ban { color: var(--danger); }
+  .empty, .error { color: var(--muted); padding: 2rem 0; text-align: center; }
+  .error { color: var(--danger); }
+  #login { max-width: 420px; margin: 15vh auto 0; text-align: center; }
+  #login input { width: 100%; padding: .6rem .8rem; border-radius: .5rem;
+    border: 1px solid var(--border); background: var(--card); color: var(--text); font: inherit; }
+  #login button { margin-top: .8rem; padding: .5rem 1.5rem; border-radius: 999px;
+    border: 1px solid var(--accent); background: var(--accent); color: #fff;
+    font: inherit; font-weight: 700; cursor: pointer; }
+  .linkish { background: none; border: none; color: var(--muted); cursor: pointer;
+    font: inherit; font-size: .85rem; text-decoration: underline; padding: 0; }
+  .hash { font-family: ui-monospace, monospace; font-size: .78rem; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div id="login" hidden>
+    <h1>Blog Comments Admin</h1>
+    <p>Paste the admin token (stored only in this browser).</p>
+    <input id="token-input" type="password" placeholder="admin token" autocomplete="off">
+    <br><button id="login-btn">Unlock</button>
+    <p id="login-error" class="error" hidden>That token was rejected.</p>
+  </div>
+
+  <div id="app" hidden>
+    <header>
+      <h1>Blog Comments Admin</h1>
+      <button class="linkish" id="logout">forget token</button>
+    </header>
+    <nav id="tabs"></nav>
+    <div id="list"></div>
+  </div>
+</div>
+
+<script>
+"use strict";
+const SITE_URL = "https://sandeep.ramgolam.com";
+const TABS = ["pending", "approved", "spam", "bans"];
+let token = localStorage.getItem("comments_admin_token") || "";
+let tab = "pending";
+
+const $ = (sel) => document.querySelector(sel);
+const el = (t, cls, text) => {
+  const n = document.createElement(t);
+  if (cls) n.className = cls;
+  if (text !== undefined) n.textContent = text;
+  return n;
+};
+
+async function api(path, { method = "GET", body } = {}) {
+  const headers = { Authorization: "Bearer " + token };
+  if (body) headers["Content-Type"] = "application/json";
+  const res = await fetch("/api/admin" + path, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  if (res.status === 401) { showLogin(true); throw new Error("unauthorized"); }
+  if (!res.ok) throw new Error("HTTP " + res.status);
+  return res.json();
+}
+
+function showLogin(rejected) {
+  $("#app").hidden = true;
+  $("#login").hidden = false;
+  $("#login-error").hidden = !rejected;
+}
+
+async function unlock() {
+  token = $("#token-input").value.trim();
+  try {
+    await api("/comments?limit=1");
+    localStorage.setItem("comments_admin_token", token);
+    $("#login").hidden = true;
+    $("#app").hidden = false;
+    load();
+  } catch { /* 401 already re-showed the login form */ }
+}
+
+function renderTabs() {
+  $("#tabs").replaceChildren(...TABS.map((t) => {
+    const b = el("button", t === tab ? "active" : "", t);
+    b.onclick = () => { tab = t; renderTabs(); load(); };
+    return b;
+  }));
+}
+
+function actionButton(label, cls, request, needsConfirm) {
+  const b = el("button", cls, label);
+  b.onclick = async () => {
+    if (needsConfirm && !confirm(label + " — are you sure?")) return;
+    try { await api(request.path, request); load(); }
+    catch (e) { if (e.message !== "unauthorized") alert(label + " failed: " + e.message); }
+  };
+  return b;
+}
+
+function commentCard(c) {
+  const card = el("div", "card");
+  const meta = el("div", "meta");
+  meta.append(el("b", "", c.author_name || "Anonymous"));
+  const link = el("a", "", c.slug);
+  link.href = SITE_URL + "/blog/" + c.slug;
+  link.target = "_blank";
+  meta.append(link, el("span", "", new Date(c.created_at).toLocaleString()));
+  if (c.parent_id) meta.append(el("span", "", "\\u21b3 reply to #" + c.parent_id));
+  meta.append(el("span", "hash", "ip:" + c.ip_hash.slice(0, 10) + "…"));
+  card.append(meta, el("p", "body", c.body));
+
+  const actions = el("div", "actions");
+  if (c.status !== "approved")
+    actions.append(actionButton("approve", "approve", { path: "/comments/" + c.id + "/approve", method: "POST" }));
+  if (c.status !== "spam")
+    actions.append(actionButton("spam", "spam", { path: "/comments/" + c.id + "/spam", method: "POST" }));
+  actions.append(actionButton("delete", "del", { path: "/comments/" + c.id, method: "DELETE" }, true));
+  actions.append(actionButton("ban IP", "ban", {
+    path: "/bans", method: "POST",
+    body: { ip_hash: c.ip_hash, reason: "banned from admin UI" },
+  }, true));
+  card.append(actions);
+  return card;
+}
+
+function banCard(b) {
+  const card = el("div", "card");
+  const meta = el("div", "meta");
+  meta.append(el("span", "hash", b.ip_hash));
+  meta.append(el("span", "", (b.reason || "no reason") + " · " + new Date(b.created_at).toLocaleString()));
+  const actions = el("div", "actions");
+  actions.append(actionButton("unban", "approve", { path: "/bans/" + b.ip_hash, method: "DELETE" }));
+  card.append(meta, actions);
+  return card;
+}
+
+async function load() {
+  const list = $("#list");
+  list.replaceChildren(el("div", "empty", "Loading…"));
+  try {
+    if (tab === "bans") {
+      const data = await api("/bans");
+      list.replaceChildren(...(data.bans.length ? data.bans.map(banCard) : [el("div", "empty", "No bans.")]));
+    } else {
+      const data = await api("/comments?status=" + tab + "&limit=200");
+      list.replaceChildren(...(data.comments.length ? data.comments.map(commentCard) : [el("div", "empty", "Nothing in " + tab + ".")]));
+    }
+  } catch (e) {
+    if (e.message !== "unauthorized") list.replaceChildren(el("div", "error", "Failed to load: " + e.message));
+  }
+}
+
+$("#login-btn").onclick = unlock;
+$("#token-input").addEventListener("keydown", (e) => { if (e.key === "Enter") unlock(); });
+$("#logout").onclick = () => { localStorage.removeItem("comments_admin_token"); token = ""; showLogin(false); };
+
+renderTabs();
+if (token) { $("#app").hidden = false; load(); }
+else showLogin(false);
+</script>
+</body>
+</html>`;

--- a/comments-worker/src/index.ts
+++ b/comments-worker/src/index.ts
@@ -4,25 +4,33 @@ import type { Env } from "./types";
 import { bearerAuth } from "./middleware/auth";
 import { publicRoutes } from "./routes/public";
 import { adminRoutes } from "./routes/admin";
+import { ADMIN_HTML } from "./admin-page";
 
 const ALLOWED_ORIGINS = ["https://sandeep.ramgolam.com", "http://localhost:4242"];
 
 const app = new Hono<{ Bindings: Env }>();
 
-const corsMiddleware = cors({
-  origin: ALLOWED_ORIGINS,
-  allowMethods: ["GET", "POST", "OPTIONS"],
-  allowHeaders: ["Content-Type"],
-  maxAge: 86400,
-});
-// Registered before routes so preflights and 4xx error responses carry CORS
-// headers. Admin routes intentionally get no CORS — they are curl/agent only.
-app.use("/api/comments", corsMiddleware);
-app.use("/api/comments/*", corsMiddleware);
+// Registered before routes (and before auth) so preflights and 4xx error
+// responses carry CORS headers. Admin routes are CORS-enabled too so the blog
+// can show the pending queue to a logged-in admin — the bearer token is the
+// security boundary, not CORS.
+app.use(
+  "/api/*",
+  cors({
+    origin: ALLOWED_ORIGINS,
+    allowMethods: ["GET", "POST", "DELETE", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization"],
+    maxAge: 86400,
+  }),
+);
 
 app.use("/api/admin/*", bearerAuth);
 
 app.get("/", (c) => c.json({ name: "comments-worker", ok: true }));
+
+// Static dashboard shell — holds no data; every request it makes goes through
+// the bearer-auth /api/admin/* endpoints.
+app.get("/admin", (c) => c.html(ADMIN_HTML));
 
 app.route("/api", publicRoutes);
 app.route("/api/admin", adminRoutes);

--- a/comments-worker/src/lib/validate.ts
+++ b/comments-worker/src/lib/validate.ts
@@ -7,6 +7,7 @@ export type ValidSubmission = {
   turnstile_token: string;
   website: string;
   form_started_at: number;
+  parent_id: number | null;
 };
 
 export type ValidationResult =
@@ -40,6 +41,14 @@ export function validateSubmission(input: unknown): ValidationResult {
     return { ok: false, message: "Missing Turnstile token" };
   }
 
+  let parentId: number | null = null;
+  if (raw.parent_id !== undefined && raw.parent_id !== null) {
+    if (typeof raw.parent_id !== "number" || !Number.isInteger(raw.parent_id) || raw.parent_id < 1) {
+      return { ok: false, message: "Invalid parent_id" };
+    }
+    parentId = raw.parent_id;
+  }
+
   return {
     ok: true,
     data: {
@@ -50,6 +59,7 @@ export function validateSubmission(input: unknown): ValidationResult {
       website: typeof raw.website === "string" ? raw.website : "",
       form_started_at:
         typeof raw.form_started_at === "number" ? raw.form_started_at : 0,
+      parent_id: parentId,
     },
   };
 }

--- a/comments-worker/src/routes/admin.ts
+++ b/comments-worker/src/routes/admin.ts
@@ -51,13 +51,16 @@ adminRoutes.post("/comments/:id/spam", (c) => setStatus(c, "spam"));
 
 adminRoutes.delete("/comments/:id", async (c) => {
   const id = c.req.param("id");
-  const row = await c.env.DB.prepare("DELETE FROM comments WHERE id = ?1 RETURNING id")
+  // Deleting a top-level comment takes its replies with it.
+  const res = await c.env.DB.prepare(
+    "DELETE FROM comments WHERE id = ?1 OR parent_id = ?1",
+  )
     .bind(id)
-    .first<{ id: number }>();
-  if (!row) {
+    .run();
+  if (res.meta.changes === 0) {
     return c.json({ error: "not_found", message: `No comment with id ${id}` }, 404);
   }
-  return c.json({ id: row.id, deleted: true });
+  return c.json({ id: Number(id), deleted: true });
 });
 
 adminRoutes.get("/bans", async (c) => {

--- a/comments-worker/src/routes/public.ts
+++ b/comments-worker/src/routes/public.ts
@@ -13,7 +13,7 @@ export const publicRoutes = new Hono<{ Bindings: Env }>();
 publicRoutes.get("/comments/:slug", async (c) => {
   const slug = c.req.param("slug");
   const { results } = await c.env.DB.prepare(
-    `SELECT id, COALESCE(author_name, 'Anonymous') AS author_name, body, created_at
+    `SELECT id, COALESCE(author_name, 'Anonymous') AS author_name, body, parent_id, created_at
      FROM comments
      WHERE slug = ?1 AND status = 'approved'
      ORDER BY created_at ASC, id ASC`,
@@ -63,6 +63,23 @@ publicRoutes.post("/comments", async (c) => {
     .first();
   if (banned) return fakeAccept(c);
 
+  // One level of threading: a reply must target an approved, top-level
+  // comment on the same post.
+  if (data.parent_id !== null) {
+    const parent = await c.env.DB.prepare(
+      `SELECT 1 FROM comments
+       WHERE id = ?1 AND slug = ?2 AND status = 'approved' AND parent_id IS NULL`,
+    )
+      .bind(data.parent_id, data.slug)
+      .first();
+    if (!parent) {
+      return c.json(
+        { error: "validation_failed", message: "Invalid parent comment" },
+        400,
+      );
+    }
+  }
+
   const human = await verifyTurnstile(c.env.TURNSTILE_SECRET, data.turnstile_token, ip);
   if (!human) {
     return c.json(
@@ -72,11 +89,11 @@ publicRoutes.post("/comments", async (c) => {
   }
 
   const row = await c.env.DB.prepare(
-    `INSERT INTO comments (slug, author_name, body, ip_hash, user_agent)
-     VALUES (?1, ?2, ?3, ?4, ?5)
+    `INSERT INTO comments (slug, author_name, body, parent_id, ip_hash, user_agent)
+     VALUES (?1, ?2, ?3, ?4, ?5, ?6)
      RETURNING id`,
   )
-    .bind(data.slug, data.author_name, data.body, ipHash, c.req.header("User-Agent") ?? null)
+    .bind(data.slug, data.author_name, data.body, data.parent_id, ipHash, c.req.header("User-Agent") ?? null)
     .first<{ id: number }>();
 
   const id = row!.id;

--- a/comments-worker/src/types.ts
+++ b/comments-worker/src/types.ts
@@ -32,5 +32,6 @@ export type PublicComment = {
   id: number;
   author_name: string;
   body: string;
+  parent_id: number | null;
   created_at: string;
 };

--- a/components/blog-comments.vue
+++ b/components/blog-comments.vue
@@ -6,18 +6,93 @@ const props = defineProps<{ slug: string }>();
 const config = useRuntimeConfig();
 const apiBase = config.public.commentsApiUrl;
 
-const comments = ref<PublicComment[]>([]);
+// Same key the admin dashboard uses — but localStorage is per-origin, so the
+// token must be set once on this site's origin (see comments-worker/README.md).
+const ADMIN_TOKEN_KEY = "comments_admin_token";
+
+type DisplayComment = PublicComment & { pending?: boolean };
+
+const comments = ref<DisplayComment[]>([]);
 const loading = ref(true);
 const loadFailed = ref(false);
+
+// Best-effort admin extra: when the moderator's token is in localStorage,
+// pending comments show inline with a badge. No token → no admin request.
+async function loadPendingAsAdmin(): Promise<DisplayComment[]> {
+  const token = localStorage.getItem(ADMIN_TOKEN_KEY);
+  if (!token) return [];
+  try {
+    const res = await $fetch<{ comments: Array<PublicComment & { author_name: string | null }> }>(
+      `${apiBase}/api/admin/comments`,
+      {
+        query: { status: "pending", slug: props.slug },
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    );
+    return res.comments.map((c) => ({
+      id: c.id,
+      author_name: c.author_name ?? "Anonymous",
+      body: c.body,
+      parent_id: c.parent_id,
+      created_at: c.created_at,
+      pending: true,
+    }));
+  } catch {
+    return []; // stale token or offline — never break the public list
+  }
+}
+
+// Commenters keep seeing their own not-yet-approved comments (remembered in
+// localStorage) so a pending comment doesn't look like it silently vanished.
+const MINE_KEY = "comments_mine";
+const MINE_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 60; // stop showing after 60 days
+
+function readMine(): DisplayComment[] {
+  try {
+    const store = JSON.parse(localStorage.getItem(MINE_KEY) ?? "{}");
+    const entries: DisplayComment[] = store[props.slug] ?? [];
+    return entries.filter(
+      (c) => Date.now() - new Date(c.created_at).getTime() < MINE_MAX_AGE_MS,
+    );
+  } catch {
+    return [];
+  }
+}
+
+function writeMine(entries: DisplayComment[]) {
+  try {
+    const store = JSON.parse(localStorage.getItem(MINE_KEY) ?? "{}");
+    if (entries.length) store[props.slug] = entries;
+    else delete store[props.slug];
+    localStorage.setItem(MINE_KEY, JSON.stringify(store));
+  } catch {
+    // storage unavailable (private mode etc.) — feature degrades gracefully
+  }
+}
+
+function sortByDate(list: DisplayComment[]): DisplayComment[] {
+  return [...list].sort((a, b) => a.created_at.localeCompare(b.created_at));
+}
 
 async function loadComments() {
   loading.value = true;
   loadFailed.value = false;
   try {
-    const res = await $fetch<PublicCommentsResponse>(
-      `${apiBase}/api/comments/${props.slug}`,
-    );
-    comments.value = res.comments;
+    const [res, adminPending] = await Promise.all([
+      $fetch<PublicCommentsResponse>(`${apiBase}/api/comments/${props.slug}`),
+      loadPendingAsAdmin(),
+    ]);
+    // Own comments that got approved (or that the admin view already covers)
+    // no longer need the local copy.
+    const approvedIds = new Set(res.comments.map((c) => c.id));
+    const mine = readMine();
+    const stillPending = mine.filter((c) => !approvedIds.has(c.id));
+    if (stillPending.length !== mine.length) writeMine(stillPending);
+    const adminIds = new Set(adminPending.map((c) => c.id));
+    const mineToShow = stillPending
+      .filter((c) => !adminIds.has(c.id))
+      .map((c) => ({ ...c, pending: true }));
+    comments.value = sortByDate([...res.comments, ...adminPending, ...mineToShow]);
   } catch {
     loadFailed.value = true;
   } finally {
@@ -25,7 +100,54 @@ async function loadComments() {
   }
 }
 
-onMounted(loadComments);
+// One level of threading: replies nest under their parent; a reply whose
+// parent isn't visible (e.g. parent deleted) falls back to top level.
+type CommentThread = { comment: DisplayComment; replies: DisplayComment[] };
+
+const threads = computed<CommentThread[]>(() => {
+  const topLevel = new Map<number, CommentThread>();
+  const orphans: DisplayComment[] = [];
+  for (const comment of comments.value) {
+    if (comment.parent_id === null) {
+      topLevel.set(comment.id, { comment, replies: [] });
+    }
+  }
+  for (const comment of comments.value) {
+    if (comment.parent_id === null) continue;
+    const parent = topLevel.get(comment.parent_id);
+    if (parent) parent.replies.push(comment);
+    else orphans.push(comment);
+  }
+  return [
+    ...topLevel.values(),
+    ...orphans.map((comment) => ({ comment, replies: [] })),
+  ];
+});
+
+// Fetch lazily — only when the reader actually scrolls near the comments —
+// so plain pageviews never hit the API.
+const sectionEl = ref<HTMLElement | null>(null);
+let observer: IntersectionObserver | null = null;
+
+onMounted(() => {
+  if (!sectionEl.value || !("IntersectionObserver" in window)) {
+    loadComments();
+    return;
+  }
+  observer = new IntersectionObserver(
+    (entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        observer?.disconnect();
+        observer = null;
+        loadComments();
+      }
+    },
+    { rootMargin: "300px" },
+  );
+  observer.observe(sectionEl.value);
+});
+
+onUnmounted(() => observer?.disconnect());
 
 const authorName = ref("");
 const body = ref("");
@@ -34,6 +156,13 @@ const formStartedAt = ref(0);
 const submitting = ref(false);
 const submitted = ref(false);
 const submitError = ref("");
+const replyTo = ref<DisplayComment | null>(null);
+const bodyEl = ref<HTMLTextAreaElement | null>(null);
+
+function startReply(comment: DisplayComment) {
+  replyTo.value = comment;
+  bodyEl.value?.focus();
+}
 
 const turnstileEl = ref<HTMLElement | null>(null);
 const { preload, getToken, reset } = useTurnstile(turnstileEl);
@@ -72,8 +201,22 @@ async function submit() {
       turnstile_token: token,
       website: website.value,
       form_started_at: formStartedAt.value,
+      parent_id: replyTo.value?.id,
     };
-    await $fetch(`${apiBase}/api/comments`, { method: "POST", body: submission });
+    const created = await $fetch<{ id: number }>(`${apiBase}/api/comments`, {
+      method: "POST",
+      body: submission,
+    });
+    const mineComment: DisplayComment = {
+      id: created.id,
+      author_name: authorName.value.trim() || "Anonymous",
+      body: body.value.trim(),
+      parent_id: replyTo.value?.id ?? null,
+      created_at: new Date().toISOString(),
+      pending: true,
+    };
+    writeMine([...readMine(), mineComment]);
+    comments.value = sortByDate([...comments.value, mineComment]);
     submitted.value = true;
   } catch (error) {
     reset();
@@ -85,7 +228,7 @@ async function submit() {
 </script>
 
 <template>
-  <section class="mt-16 mb-24">
+  <section ref="sectionEl" class="mt-16 mb-24">
     <h2 class="text-2xl font-bold mb-6">Comments</h2>
 
     <ClientOnly>
@@ -104,24 +247,78 @@ async function submit() {
 
       <template v-else>
         <p v-if="comments.length === 0" class="text-gray-500 dark:text-gray-400">
-          No comments yet — be the first!
+          It's quiet in here. Say hi 👋
         </p>
         <ul v-else class="flex flex-col gap-4 list-none p-0">
-          <li
-            v-for="comment in comments"
-            :key="comment.id"
-            class="rounded-xl border border-gray-200 dark:border-gray-800 p-4"
-          >
-            <div class="flex items-baseline gap-2 mb-1">
-              <span class="font-bold">{{ comment.author_name }}</span>
-              <time
-                class="text-sm text-gray-500 dark:text-gray-400"
-                :datetime="comment.created_at"
+          <li v-for="thread in threads" :key="thread.comment.id">
+            <article
+              class="rounded-xl border p-4"
+              :class="
+                thread.comment.pending
+                  ? 'border-dashed border-amber-400/60 opacity-80'
+                  : 'border-gray-200 dark:border-gray-800'
+              "
+            >
+              <div class="flex items-baseline gap-2 mb-1">
+                <span class="font-bold">{{ thread.comment.author_name }}</span>
+                <time
+                  class="text-sm text-gray-500 dark:text-gray-400"
+                  :datetime="thread.comment.created_at"
+                >
+                  {{ dateFormat(new Date(thread.comment.created_at)) }}
+                </time>
+                <span
+                  v-if="thread.comment.pending"
+                  class="text-xs uppercase tracking-wide rounded-full border border-amber-400 text-amber-600 dark:text-amber-400 px-2 py-0.5"
+                >
+                  pending
+                </span>
+              </div>
+              <p class="whitespace-pre-line dark:text-gray-300 m-0">
+                {{ thread.comment.body }}
+              </p>
+              <button
+                v-if="!thread.comment.pending && !submitted"
+                type="button"
+                class="mt-2 text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 underline underline-offset-2"
+                @click="startReply(thread.comment)"
               >
-                {{ dateFormat(new Date(comment.created_at)) }}
-              </time>
-            </div>
-            <p class="whitespace-pre-line dark:text-gray-300 m-0">{{ comment.body }}</p>
+                Reply
+              </button>
+            </article>
+
+            <ul
+              v-if="thread.replies.length"
+              class="list-none p-0 mt-3 ml-4 sm:ml-8 flex flex-col gap-3 border-l-2 border-gray-200 dark:border-gray-800 pl-4"
+            >
+              <li v-for="reply in thread.replies" :key="reply.id">
+                <article
+                  class="rounded-xl border p-4"
+                  :class="
+                    reply.pending
+                      ? 'border-dashed border-amber-400/60 opacity-80'
+                      : 'border-gray-200 dark:border-gray-800'
+                  "
+                >
+                  <div class="flex items-baseline gap-2 mb-1">
+                    <span class="font-bold">{{ reply.author_name }}</span>
+                    <time
+                      class="text-sm text-gray-500 dark:text-gray-400"
+                      :datetime="reply.created_at"
+                    >
+                      {{ dateFormat(new Date(reply.created_at)) }}
+                    </time>
+                    <span
+                      v-if="reply.pending"
+                      class="text-xs uppercase tracking-wide rounded-full border border-amber-400 text-amber-600 dark:text-amber-400 px-2 py-0.5"
+                    >
+                      pending
+                    </span>
+                  </div>
+                  <p class="whitespace-pre-line dark:text-gray-300 m-0">{{ reply.body }}</p>
+                </article>
+              </li>
+            </ul>
           </li>
         </ul>
       </template>
@@ -147,12 +344,26 @@ async function submit() {
             placeholder="Name (optional)"
             class="rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2"
           />
+          <p
+            v-if="replyTo"
+            class="m-0 text-sm text-gray-500 dark:text-gray-400"
+          >
+            Replying to <span class="font-bold">{{ replyTo.author_name }}</span>
+            <button
+              type="button"
+              class="ml-2 underline underline-offset-2"
+              @click="replyTo = null"
+            >
+              cancel
+            </button>
+          </p>
           <textarea
+            ref="bodyEl"
             v-model="body"
             required
             maxlength="4000"
             rows="4"
-            placeholder="Leave a comment…"
+            :placeholder="replyTo ? `Reply to ${replyTo.author_name}…` : 'Leave a comment…'"
             class="rounded-lg border border-gray-300 dark:border-gray-700 bg-transparent px-3 py-2"
           />
           <input
@@ -175,7 +386,7 @@ async function submit() {
             :disabled="submitting || body.trim().length < 2"
             class="self-start rounded-full border-2 border-gray-900 dark:border-gray-100 px-5 py-2 font-bold transition-colors hover:bg-gray-900 hover:text-white dark:hover:bg-gray-100 dark:hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-transparent disabled:hover:text-current"
           >
-            {{ submitting ? "Posting…" : "Post comment" }}
+            {{ submitting ? "Posting…" : replyTo ? "Post reply" : "Post comment" }}
           </button>
         </form>
       </div>

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,6 +3,7 @@ export type PublicComment = {
   id: number;
   author_name: string; // already coalesced to 'Anonymous' by the API
   body: string;
+  parent_id: number | null; // one level of threading
   created_at: string; // ISO-8601
 };
 
@@ -19,6 +20,7 @@ export type CommentSubmission = {
   turnstile_token: string;
   website: string; // honeypot — always ''
   form_started_at: number; // epoch ms of first form interaction
+  parent_id?: number; // reply target (approved top-level comment)
 };
 
 export type BlogPost = {


### PR DESCRIPTION
## Summary

Follow-ups to #16, all verified end-to-end locally and the worker half already deployed:

- **Browser moderation**: the worker now serves a single-file admin dashboard at `https://comments.ramgolam.com/admin` — paste the admin token once (localStorage), then approve/spam/delete/ban from pending/approved/spam/bans tabs.
- **Threaded replies (one level)**: `parent_id` validated server-side (must be an approved top-level comment on the same slug); deleting a parent cascades to its replies; Reply button + "Replying to…" flow in the blog embed.
- **Lazy loading**: the comments fetch only fires when the reader scrolls near the section (IntersectionObserver) — plain pageviews never hit the API.
- **Admin view on the blog**: with the admin token in the blog origin's localStorage, pending comments render inline with a badge; without a token no admin request is made. Admin API is now CORS-enabled for the blog origin (auth stays on the bearer token).
- **Own pending comments**: commenters keep seeing their own not-yet-approved comments (localStorage, per slug, 60-day cap) so submissions don't appear to vanish; the local copy is dropped once approved.
- Friendlier empty-state copy.

## Test plan

- [x] curl: reply lifecycle (valid parent 201, nonexistent/pending parent 400), GET returns parent_id, cascade delete
- [x] Browser (local): admin dashboard login/approve/spam/tabs; threading render + reply form flow; lazy fetch (no API call until scroll); pending-inline with token, none without; own-pending survives reload, clears after approval
- [x] Prod worker deployed; /admin live; admin CORS preflight verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)