### PR TITLE
Fix frozen navigation caused by stray view transitions

### DIFF
--- a/components/blog-table-of-content.vue
+++ b/components/blog-table-of-content.vue
@@ -6,6 +6,7 @@ const props = withDefaults(
   {},
 );
 const router = useRouter();
+const route = useRoute();
 
 const sliderHeight = useState("sliderHeight", () => 0);
 const sliderTop = useState("sliderTop", () => 0);
@@ -23,7 +24,10 @@ const tocLinks = computed(() => blogPost?.value?.body?.toc?.links ?? []);
 const onClick = (id: string) => {
   const el = document.getElementById(id);
   if (el) {
-    router.push({ hash: `#${id}` });
+    // Keep the current path and query: re-resolving the path drops the
+    // trailing slash and the fake "page change" starts a view transition
+    // that freezes rendering (see events-listing.vue).
+    router.push({ path: route.path, query: route.query, hash: `#${id}` });
     el.scrollIntoView({
       behavior: "smooth",
       block: "center",

--- a/components/events-listing.vue
+++ b/components/events-listing.vue
@@ -56,9 +56,13 @@ const presentAsList: {
 const route = useRoute();
 const router = useRouter();
 
-const currentEventType: Ref<EventType> = ref(
-  (route.query.type as EventType) || "all"
-);
+// The URL is the source of truth so direct links and back/forward work
+const currentEventType = computed<EventType>(() => {
+  const type = route.query.type;
+  return typeof type === "string" && type in presentAsList
+    ? (type as EventType)
+    : "all";
+});
 
 const eventsSortedByDate = computed(() => {
   if (localEvents.value && localEvents.value.length === 0) {
@@ -114,11 +118,14 @@ const filterOptions: { type: EventType; label: string; color?: string; textClass
 
 function setCurrentEventType(eventType: EventType) {
   const newType = currentEventType.value === eventType ? "all" : eventType;
-  currentEventType.value = newType;
+  // Keep the current path: letting the router re-resolve it drops the
+  // trailing slash the static host serves, and that fake "page change"
+  // starts a view transition that freezes rendering for seconds.
   router.push({
+    path: route.path,
     query: {
       ...route.query,
-      type: currentEventType.value === "all" ? undefined : currentEventType.value,
+      type: newType === "all" ? undefined : newType,
     },
   });
 }

--- a/plugins/view-transition-watchdog.client.ts
+++ b/plugins/view-transition-watchdog.client.ts
@@ -1,0 +1,16 @@
+// Chrome freezes rendering from the moment a view transition starts until
+// the new page has finished loading. If that takes too long (slow payload,
+// or a navigation where `page:finish` never fires), the browser holds the
+// freeze until it force-aborts the transition after ~4s. Skip the animation
+// once it overstays — skipTransition() unfreezes rendering but still lets
+// the navigation itself complete.
+export default defineNuxtPlugin((nuxtApp) => {
+  let watchdog: ReturnType<typeof setTimeout> | undefined;
+
+  nuxtApp.hook("page:view-transition:start", (transition) => {
+    clearTimeout(watchdog);
+    watchdog = setTimeout(() => transition.skipTransition(), 1500);
+  });
+
+  nuxtApp.hook("page:finish", () => clearTimeout(watchdog));
+});


### PR DESCRIPTION
Filtering on the events page froze the screen for a few seconds because the query-only router.push dropped the trailing slash, and Nuxt treated the path change as a page change and started a view transition that never finished. Keeps the path stable on filter and TOC clicks, drives the events filter from the URL so direct links and back/forward work, and adds a small watchdog that skips any view transition that overstays so navigation can never freeze the page.